### PR TITLE
Animation & Ability Update

### DIFF
--- a/Abilities/Ability.cs
+++ b/Abilities/Ability.cs
@@ -11,7 +11,7 @@ namespace GameDevIdiotsProject1.Abilities
 		protected float currentTime;
 		protected float startup;
 		protected float cooldown;
-		protected float duration;
+		public float duration { get; protected set; }
 		protected string startAnimation;
 		protected string updateAnimation;
 		protected string endAnimation;

--- a/Abilities/DefaultAbility.cs
+++ b/Abilities/DefaultAbility.cs
@@ -44,11 +44,14 @@ namespace GameDevIdiotsProject1.Abilities
 		{
 			currentTime = 0;
 			state = AbilityState.COOLDOWN;
+			ref Animate animate= ref entity.Get<Animate>();
+
+			//reset the current animation to first frame to prevent weird animation looping
+			animate.AnimationList[animate.currentAnimation].Reset();
 
 			if (endAnimation != null)
 			{
-				ref string animation = ref entity.Get<Animate>().currentAnimation;
-				animation = endAnimation;
+				animate.currentAnimation = endAnimation;
 			}
 		}
 	}

--- a/Abilities/DodgeRoll.cs
+++ b/Abilities/DodgeRoll.cs
@@ -8,13 +8,14 @@ namespace GameDevIdiotsProject1.Abilities
 	{
 		private const float SPEED_BOOST = 1.8f;
 		private const float COOLDOWN = 200;
-		private const float DURATION = 400;
+		private static float DURATION = 400;
 		private const string ANIMATION_KEY = "dodge-roll";
 
 		public DodgeRoll(Command command) : base(command)
 		{
 			cooldown = COOLDOWN;
 			duration = DURATION;
+			startAnimation = ANIMATION_KEY;
 			updateAnimation = ANIMATION_KEY;
 			endAnimation = DEFAULT_IDLE_ANIMATION;
 
@@ -42,5 +43,10 @@ namespace GameDevIdiotsProject1.Abilities
 			ref Velocity velocity = ref entity.Get<Velocity>();
 			velocity.speed /= SPEED_BOOST;
 		}
+
+		public static float GetDuration()
+        {
+			return DURATION;
+        }
 	}
 }

--- a/Abilities/DoubleTapAbility.cs
+++ b/Abilities/DoubleTapAbility.cs
@@ -5,8 +5,16 @@ namespace GameDevIdiotsProject1.Abilities
 {
 	abstract class DoubleTapAbility : DefaultAbility
 	{
+		/// <summary>
+        /// Default time between consecutive key presses. Applied when not specified in constructor.
+        /// </summary>
 		private const float DEFAULT_MAX_WINDOW = 200;
+
+		/// <summary>
+		/// Maximum amount of time allowed between consecutive key presses
+		/// </summary>
 		private readonly float _maxWindow;
+
 		private bool _released;
 		
 		public DoubleTapAbility(Command command, float maxWindow = DEFAULT_MAX_WINDOW) : base (command)
@@ -16,11 +24,12 @@ namespace GameDevIdiotsProject1.Abilities
 
 		public override void Start(in Entity entity)
 		{
+			
 			if (state == AbilityState.AVAILABLE && currentTime < _maxWindow)
 			{
 				if (_released)
 					Action(in entity);
-			} 
+			}
 			else if (currentTime > _maxWindow)
 			{
 				_released = false;

--- a/DefaultEcs/Entities/Enemy.cs
+++ b/DefaultEcs/Entities/Enemy.cs
@@ -54,7 +54,6 @@ namespace GameDevIdiotsProject1.DefaultEcs.Entities
 
 			//Idle Animation
 			Animation idle = new Animation();
-			idle.Loop = true;
 			idle.AddFrame(new Rectangle(0, 0, IDLE_SPRITE_WIDTH, IDLE_SPRITE_HEIGHT), TimeSpan.FromSeconds(IDLE_FRAME_LENGTH));
 			idle.AddFrame(new Rectangle(IDLE_SPRITE_WIDTH, 0, IDLE_SPRITE_WIDTH, IDLE_SPRITE_HEIGHT), TimeSpan.FromSeconds(IDLE_FRAME_LENGTH));
 			

--- a/DefaultEcs/Entities/Player.cs
+++ b/DefaultEcs/Entities/Player.cs
@@ -72,59 +72,6 @@ namespace GameDevIdiotsProject1.DefaultEcs.Entities
 			player.Set(new Collision(actor));
 			collisionComponent.Insert(actor);
 
-            #region create-animations
-            // Animations
-            var AnimationTable = new Dictionary<string, Animation>();
-
-			// CREATE ANIMATIONS (should probably make a function that automates this)
-			Animation walkDown = new Animation();
-			walkDown.Loop = true;
-			walkDown.AddFrame(new Rectangle(0, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
-			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
-			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH * 2, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
-			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH * 3, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
-			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH * 4, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
-			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH * 5, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
-
-			// Dodge Roll Animation
-			Animation dodgeRoll = new Animation();
-			dodgeRoll.Loop = false;
-			//dodgeRoll.AddFrame(new Rectangle(0, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_WIDTH), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			//dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 2, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(.05f));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 3, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(.05f));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 4, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(.05f));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 5, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(.05f));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 6, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_WIDTH), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 7, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 8, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 9, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 10, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 11, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 12, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_WIDTH), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 13, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			//dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 14, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-			//dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 15, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
-
-			//Idle Animation
-			Animation idle = new Animation();
-			idle.Loop = true;
-			idle.AddFrame(new Rectangle(0, 0, IDLE_SPRITE_WIDTH, IDLE_SPRITE_HEIGHT), TimeSpan.FromSeconds(IDLE_FRAME_LENGTH));
-			idle.AddFrame(new Rectangle(IDLE_SPRITE_WIDTH, 0, IDLE_SPRITE_WIDTH, IDLE_SPRITE_HEIGHT), TimeSpan.FromSeconds(IDLE_FRAME_LENGTH));
-
-			// Add to List
-			AnimationTable["walk"] = walkDown;
-			AnimationTable["dodge-roll"] = dodgeRoll;
-			AnimationTable["idle"] = idle;
-
-			//set animations
-			player.Set(new Animate {
-				AnimationList = AnimationTable,
-				currentAnimation = "idle"
-			});
-
-			#endregion
-
 
 			// Abilities
 			var abilities = new List<Ability>()
@@ -142,7 +89,58 @@ namespace GameDevIdiotsProject1.DefaultEcs.Entities
 				new Dash(new KeyCommand(Keys.D), MovementDirection.RIGHT),
 				new SpeedBuff(new KeyCommand(Keys.E))
 			};
-			
+
+			#region create-animations
+			// Animations
+			var AnimationTable = new Dictionary<string, Animation>();
+
+			// CREATE ANIMATIONS (should probably make a function that automates this)
+			Animation walkDown = new Animation();
+			walkDown.AddFrame(new Rectangle(0, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
+			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
+			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH * 2, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
+			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH * 3, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
+			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH * 4, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
+			walkDown.AddFrame(new Rectangle(0 + WALK_SPRITE_WIDTH * 5, 16, WALK_SPRITE_WIDTH, WALK_SPRITE_HEIGHT), TimeSpan.FromSeconds(WALK_FRAME_LENGTH));
+
+			// Dodge Roll Animation
+			Animation dodgeRoll = new Animation(DodgeRoll.GetDuration());
+			//dodgeRoll.AddFrame(new Rectangle(0, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_WIDTH), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			//dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 2, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 3, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(.05f));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 4, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(.05f));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 5, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(.05f));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 6, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_WIDTH), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 7, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			//dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 8, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 9, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 10, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 11, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 12, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_WIDTH), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 13, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			//dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 14, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+			//dodgeRoll.AddFrame(new Rectangle(DODGE_SPRITE_WIDTH * 15, 32, DODGE_SPRITE_WIDTH, DODGE_SPRITE_HEIGHT), TimeSpan.FromSeconds(DODGE_FRAME_LENGTH));
+
+			//Idle Animation
+			Animation idle = new Animation();
+			idle.AddFrame(new Rectangle(0, 0, IDLE_SPRITE_WIDTH, IDLE_SPRITE_HEIGHT), TimeSpan.FromSeconds(IDLE_FRAME_LENGTH));
+			idle.AddFrame(new Rectangle(IDLE_SPRITE_WIDTH, 0, IDLE_SPRITE_WIDTH, IDLE_SPRITE_HEIGHT), TimeSpan.FromSeconds(IDLE_FRAME_LENGTH));
+
+			// Add to List
+			AnimationTable["walk"] = walkDown;
+			AnimationTable["dodge-roll"] = dodgeRoll;
+			AnimationTable["idle"] = idle;
+
+			//set animations
+			player.Set(new Animate
+			{
+				AnimationList = AnimationTable,
+				currentAnimation = "idle"
+			});
+
+			#endregion
+
 
 			player.Set(new CombatStats
 			{

--- a/DefaultEcs/Systems/PlayerSystem.cs
+++ b/DefaultEcs/Systems/PlayerSystem.cs
@@ -62,14 +62,19 @@ namespace GameDevIdiotsProject1.DefaultEcs.Systems
 			// Check if any abilities should be triggered
 			foreach (Ability ability in abilities)
 			{
+				//skip if the command attached to the ability is not pressed, or the
+				//ability is not available AND not currently active (is this essentially "if in Cooldown?")
 				if (!ability.command.IsPressed() || (ability.state != AbilityState.AVAILABLE && ability.state != AbilityState.ACTIVE))
 					continue;
 
+				Console.WriteLine(currentAbility.state);
 				// If current ability is over, the ability is instant, or ability can override
-				if (currentAbility.state != AbilityState.PERFORMING
-					|| ability.types.Contains(AbilityType.INSTANT)
-					|| (currentAbility.types.Contains(AbilityType.OVERRIDABLE) && ability.types.Contains(AbilityType.INTERRUPT)))
+				if ((currentAbility.state != AbilityState.PERFORMING
+					&& currentAbility.state != AbilityState.STARTING)
+					|| (ability.types.Contains(AbilityType.INSTANT)
+					|| (currentAbility.types.Contains(AbilityType.OVERRIDABLE) && ability.types.Contains(AbilityType.INTERRUPT))))
 				{
+					Console.WriteLine(currentAbility);
 					ability.Start(in entity);
 					currentAbility = ability;
 				}

--- a/Graphics/Animation.cs
+++ b/Graphics/Animation.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using GameDevIdiotsProject1.Abilities;
+using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,7 +8,15 @@ namespace GameDevIdiotsProject1.Graphics {
     public class Animation {
         List<AnimationFrame> frames;
         TimeSpan timeIntoAnimation;
-        public bool Loop { get; set; }
+        float abilityDuration;
+
+        //specify default constructor
+        public Animation() { }
+        //constructor for ability animations
+        public Animation(float abilityDuration)
+        {
+            this.abilityDuration = abilityDuration;
+        }
 
         // custom Duration accessor, because the length will change whenever a frame is added
         TimeSpan Duration {
@@ -50,11 +59,50 @@ namespace GameDevIdiotsProject1.Graphics {
             }
         }
 
-        public void AddFrame(Rectangle rectangle, TimeSpan duration) {
+        public void AddFrame(Rectangle rectangle)
+        {
+            //default TimeSpan
+            TimeSpan duration = TimeSpan.FromSeconds(.05);
+
             if (frames == null)
                 frames = new List<AnimationFrame>();
 
-            AnimationFrame newFrame = new AnimationFrame() {
+            //check if this animation is linked to an ability
+            if (abilityDuration != 0)
+            {
+                //update frame length automatically
+                duration = TimeSpan.FromSeconds((abilityDuration/(frames.Count+1))/1000);
+
+                //iterate through existing frames, update with new frame length
+                foreach (AnimationFrame frame in frames)
+                {
+                    frame.Duration = duration;
+                }
+            }
+
+            AnimationFrame newFrame = new AnimationFrame()
+            {
+                SourceRectangle = rectangle,
+                Duration = duration
+            };
+
+            frames.Add(newFrame);
+        }
+
+        public void AddFrame(Rectangle rectangle, TimeSpan duration)
+        {
+            if (frames == null)
+                frames = new List<AnimationFrame>();
+
+            //if attempting to use on an Ability Animation, redirect to Ability AddFrame
+            if (abilityDuration != 0)
+            {
+                AddFrame(rectangle);
+                return;
+            }
+
+            AnimationFrame newFrame = new AnimationFrame()
+            {
                 SourceRectangle = rectangle,
                 Duration = duration
             };
@@ -69,10 +117,15 @@ namespace GameDevIdiotsProject1.Graphics {
 
             double remainder = secondsIntoAnimation % Duration.TotalSeconds;
 
-            timeIntoAnimation = TimeSpan.FromSeconds(remainder);
-            
+            if (secondsIntoAnimation > Duration.TotalSeconds)
+                remainder = 0;
 
-            
+            timeIntoAnimation = TimeSpan.FromSeconds(remainder);
+        }
+
+        public void Reset()
+        {
+            timeIntoAnimation = TimeSpan.Zero;
         }
     }
 }


### PR DESCRIPTION
Fixes the issue with MovementOverride not working, basically the ability state was always either "Available" or "Starting" because we forgot to check to see if the ability was "Starting" before letting it switch to the next animation. 

Also adds in the option to auto-time your animation frames to an ability by passing in it's duration. To aid with this and decrease overhead, I made the DURATION field in DodgeRoll static so it doesn't need to be instantiated just for us to get that value. Also added a Reset function to animations so that they can be reset to the first frame when an ability ends (this fixes some weird animation looping that was happening)